### PR TITLE
Removing servername being prepended to url

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -139,9 +139,9 @@ resource "aws_autoscaling_attachment" "asg_attachment_to_elb" {
   elb                    = "${aws_elb.elb_jenkins2_server.id}"
 }
 
-resource "aws_route53_record" "dns_record_asg" {
+resource "aws_route53_record" "dns_record_top" {
   zone_id = "${var.route53_team_zone_id}"
-  name    = "asg.${var.environment}"
+  name    = "${var.environment}"
   type    = "A"
 
   alias {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "github_callback_url" {
   description = "Callback uri for Github authentication flow"
-  value       = "https://${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}/securityRealm/finishLogin"
+  value       = "https://${var.environment}.${var.team_name}.${var.hostname_suffix}/securityRealm/finishLogin"
 }
 
 output "image_id" {
@@ -15,7 +15,7 @@ output "public_subnets" {
 
 output "jenkins2_url" {
   description = "URL of Jenkins instance"
-  value       = "https://${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
+  value       = "https://${var.environment}.${var.team_name}.${var.hostname_suffix}"
 }
 
 output "jenkins2_vpc_id" {

--- a/tls.tf
+++ b/tls.tf
@@ -1,11 +1,11 @@
 locals {
   san_domains = [
-    "asg.${var.environment}.${var.team_name}.${var.hostname_suffix}",
+    "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}",
   ]
 }
 
 resource "aws_acm_certificate" "tls_certificate" {
-  domain_name               = "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
+  domain_name               = "${var.environment}.${var.team_name}.${var.hostname_suffix}"
   validation_method         = "DNS"
   subject_alternative_names = "${local.san_domains}"
 


### PR DESCRIPTION
- remove redundant dns record asg.*
- add [environment].* dns record
- amend tls certs to be issued with [environment].* as primary and [server_name].* as SAN

Solo: @smford