### PR TITLE
Pin jenkins version to 2.121.2

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -47,7 +47,7 @@ data "template_file" "jenkins2_asg_server_template" {
     gitrepo              = "${var.gitrepo}"
     gitrepo_branch       = "${var.gitrepo_branch}"
     hostname             = "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
-    jenkins_version      = "${var.jenkins_version}"
+    jenkins_version      = "${local.jenkins_version}"
     region               = "${local.configured_region}"
     team                 = "${var.team_name}"
     github_admin_users   = "${join(",", var.github_admin_users)}"

--- a/variables.tf
+++ b/variables.tf
@@ -59,12 +59,6 @@ variable "hostname_suffix" {
   type        = "string"
 }
 
-variable "jenkins_version" {
-  description = "Verson of jenkins to install"
-  type        = "string"
-  default     = "2.121.2"
-}
-
 variable "public_subnet_cidr" {
   description = "CIDR blocks for public subnet"
   type        = "string"

--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "hostname_suffix" {
 variable "jenkins_version" {
   description = "Verson of jenkins to install"
   type        = "string"
-  default     = "latest"
+  default     = "2.121.2"
 }
 
 variable "public_subnet_cidr" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+locals {
+	jenkins_version = "2.121.2"
+}


### PR DESCRIPTION
Pin jenkins to 2.121.2 which is a LTS release.

Release list is available [here](https://hub.docker.com/r/jenkins/jenkins/tags/).

This change pairs with the PR which pinned the version with plugins for [20180810](alphagov/re-build-systems@138a34a)

Solo: @smford