### PR TITLE
Remove specific docker version installation

### DIFF
--- a/asg.tf
+++ b/asg.tf
@@ -41,7 +41,6 @@ data "template_file" "jenkins2_asg_server_template" {
   vars {
     awsaz                = "${local.configured_az}"
     awsenv               = "${var.environment}"
-    docker_version       = "${var.docker_version}"
     efs_file_system      = "${aws_efs_file_system.jenkins2_efs_server.id}"
     fqdn                 = "${var.server_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
     gitrepo              = "${var.gitrepo}"

--- a/cloud-init/server-asg-xenial-16.04-amd64-server.yaml
+++ b/cloud-init/server-asg-xenial-16.04-amd64-server.yaml
@@ -203,7 +203,7 @@ runcmd:
   - echo "search ${awsenv}.${team}.${awsaz}.internal" >> /etc/resolvconf/resolv.conf.d/base
   - apt-get update
   - apt-get upgrade
-  - apt-get install -y docker-ce=${docker_version}
+  - apt-get install -y docker-ce
   - systemctl status docker
   - apt-get -y install netcat
   - mkdir /docker

--- a/cloud-init/worker-xenial-16.04-amd64-server.yaml
+++ b/cloud-init/worker-xenial-16.04-amd64-server.yaml
@@ -208,7 +208,7 @@ runcmd:
   - echo "search ${awsenv}.${team}.${awsaz}.internal" >> /etc/resolvconf/resolv.conf.d/base
   - apt-get update
   - apt-get upgrade
-  - apt-get install -y docker-ce=${docker_version}
+  - apt-get install -y docker-ce
   - service docker stop
   - mkdir -p /etc/systemd/system/docker.service.d
   - mv /tmp/daemon.json /etc/docker

--- a/i-worker.tf
+++ b/i-worker.tf
@@ -30,12 +30,11 @@ data "template_file" "jenkins2_worker_template" {
   template = "${file("${path.module}/cloud-init/worker-${var.ubuntu_release}.yaml")}"
 
   vars {
-    awsaz          = "${local.configured_az}"
-    awsenv         = "${var.environment}"
-    docker_version = "${var.docker_version}"
-    fqdn           = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
-    hostname       = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
-    team           = "${var.team_name}"
+    awsaz    = "${local.configured_az}"
+    awsenv   = "${var.environment}"
+    fqdn     = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
+    hostname = "${var.worker_name}.${var.environment}.${var.team_name}.${var.hostname_suffix}"
+    team     = "${var.team_name}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,11 +8,6 @@ variable "az" {
   type        = "string"
 }
 
-variable "docker_version" {
-  description = "Docker version to install"
-  type        = "string"
-}
-
 variable "environment" {
   description = "Environment (test, staging, production, etc)"
   type        = "string"

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 locals {
-	jenkins_version = "2.121.2"
+  jenkins_version = "2.121.2"
 }


### PR DESCRIPTION
By removing specific docker version it will always install the latest.

This aligns with the upgrade process vision, and prevents legacy versions
being installed.

This pairs with [PR](https://github.com/alphagov/re-build-systems/pull/116)

Solo: @smford