### PR TITLE
Fix jenkins version pinning issue via docker build args

### DIFF
--- a/cloud-init/server-asg-xenial-16.04-amd64-server
+++ b/cloud-init/server-asg-xenial-16.04-amd64-server
@@ -39,5 +39,5 @@ sleep 90
 mount -a -t efs defaults
 chown 1000:1000 /mnt/jenkins-efs
 service docker start
-docker build -t=jenkins/jenkins-re /docker/docker
+docker build -t=jenkins/jenkins-re:${jenkins_version} --build-arg JENKINS_VERSION=${jenkins_version} /docker/docker
 docker run --name myjenkins -d -p 80:80 -p 50000:50000 -p 8080:8080 --env-file /docker/jenkinsvars -v /mnt/jenkins-efs:/var/jenkins_home jenkins/jenkins-re:${jenkins_version}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-FROM jenkins/jenkins:lts
+ARG JENKINS_VERSION
+FROM jenkins/jenkins:${JENKINS_VERSION}
 
 # 80 = nginx
 # 8080 = jenkins


### PR DESCRIPTION
The version of jenkins was not being pinned correctly and still grabs the LTS version, which during testing also matched the expected version causing tests to errornously pass.

This change fixes the issue and ensures the correct pinned version of jenkins gets installed. It also tags the docker images created with the correct pinned version.

Solo: @smford