### PR TITLE
Remove Netcat from being installed on master server

### DIFF
--- a/cloud-init/server-asg-xenial-16.04-amd64-server
+++ b/cloud-init/server-asg-xenial-16.04-amd64-server
@@ -9,7 +9,7 @@ dhclient -r; dhclient
 echo "search ${awsenv}.${team}.${awsaz}.internal" >> /etc/resolvconf/resolv.conf.d/base
 apt-get update
 apt-get upgrade
-apt-get install -y docker-ce netcat
+apt-get install -y docker-ce
 service docker stop
 mkdir -p /etc/systemd/system/docker.service.d
 cat << EOF > /etc/systemd/system/docker.service.d/override.conf


### PR DESCRIPTION
netcat was errornously installed on the master server, this is no longer needed and can be removed.

Solo: @smford