### PR TITLE
Fix groovy script that sets jenkins url

### DIFF
--- a/docker/files/groovy/configure-jenkins-url.groovy
+++ b/docker/files/groovy/configure-jenkins-url.groovy
@@ -1,4 +1,5 @@
 import jenkins.model.JenkinsLocationConfiguration
+def env = System.getenv()
 jlc = JenkinsLocationConfiguration.get()
 jlc.setUrl(env['JENKINS_URL']) 
 println(jlc.getUrl())


### PR DESCRIPTION
The script was incorrectly attempting to read in an environment variable, this fixes that.

Pair: @jonathanhallam & @smford