### PR TITLE
Add custom tags to enable dependencies between modules.

### DIFF
--- a/i-worker.tf
+++ b/i-worker.tf
@@ -16,14 +16,14 @@ module "jenkins2_worker" {
     delete_on_termination = "true"
   }]
 
-  tags {
-    AvailabilityZone = "${local.configured_az}"
-    Environment      = "${var.environment}"
-    ManagedBy        = "terraform"
-    Name             = "jenkins2_worker_ec2_${var.team_name}_${var.environment}"
-    Team             = "${var.team_name}"
-    Type             = "Jenkins-worker"
-  }
+  tags = "${merge("${var.custom_tags}",
+    map("AvailabilityZone", "${local.configured_az}"),
+    map("Environment", "${var.environment}"),
+    map("ManagedBy", "terraform"),
+    map("Name", "jenkins2_worker_ec2_${var.team_name}_${var.environment}"),
+    map("Team", "${var.team_name}"),
+    map("Type", "Jenkins-worker")
+  )}"
 }
 
 data "template_file" "jenkins2_worker_template" {

--- a/variables.tf
+++ b/variables.tf
@@ -129,3 +129,9 @@ variable "append_server_user_data" {
   type        = "string"
   default     = ""
 }
+
+variable "custom_tags" {
+  description = "(Optional) List of custom tags to apply to the resource"
+  type        = "map"
+  default     = {}
+}


### PR DESCRIPTION
This is a work-around since Terraform currently does not permit modules to be directly dependent on other modules. By passing in, for example, the name of a Cloudtrail bucket we can make this module dependent on Cloudtrail being set up in another module.

Solo: @poveyd