### PR TITLE
Update Jenkins core LTS version to 2.150.1 (2018-12-05)

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,4 @@
 locals {
-  jenkins_version = "2.138.2"
+  jenkins_version = "2.150.1"
   ubuntu_release  = "xenial-16.04-amd64-server"
 }


### PR DESCRIPTION
Required because there have been several minor LTS releases
and the latest includes important security fixes.

Co-authored-by: paroxp rafal.proszowski@digital.cabinet-office.gov.uk